### PR TITLE
Removed BT Capability

### DIFF
--- a/NLP_Control.py
+++ b/NLP_Control.py
@@ -1,11 +1,9 @@
 import snowboydecoder
 import sys
 import signal
-import concurrent.futures
 
 from GoogleAssistant import GoogleAssistant
 from i2c import I2C
-from BT import Bluetooth
 
 SLAVE_ADDR = 0x62
 interrupted = False
@@ -38,12 +36,8 @@ def startNLP(model):
 					   interrupt_check=interrupt_callback,
 		               sleep_time=0.03)
 
-	e = concurrent.futures.ThreadPoolExecutor(max_workers=1)
 	i2c = I2C(SLAVE_ADDR)
-	btServer = Bluetooth(i2c)
 	assistant = GoogleAssistant(i2c)
-
-	e.submit(btServer.operation)
 
 	# capture SIGINT signal, e.g., Ctrl+C
 	signal.signal(signal.SIGINT, signal_handler)


### PR DESCRIPTION
Removed BT capability due to the fact that i2c on pi does not allow clock stretch, which makes sending joystick data very slow.